### PR TITLE
Launcher3: Fix Wrong Icon for Truecaller

### DIFF
--- a/res/xml/grayscale_icon_map.xml
+++ b/res/xml/grayscale_icon_map.xml
@@ -1678,7 +1678,7 @@
         package="com.truecaller" />
     <icon
         drawable="@drawable/themed_icon_tinkoff"
-        package="com.truecaller" />
+        package="com.idamob.tinkoff.android" />
     <icon
         drawable="@drawable/themed_icon_fitbit"
         package="com.fitbit.FitbitMobile" />


### PR DESCRIPTION
Truecaller currently shows the icon of Tinkoff bank.